### PR TITLE
Add in a dependency on ament_lint_common for ROS 2.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,8 @@
   <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
 
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
   <member_of_group condition="$ROS_VERSION == 2">rosidl_interface_packages</member_of_group>
 
   <export>


### PR DESCRIPTION
This is because we have the linter tests enabled, which require ament_lint_common.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the failing builds on both Humble and Rolling, like: https://build.ros2.org/job/Rbin_uJ64__rtcm_msgs__ubuntu_jammy_amd64__binary/47/console

Note that this may actually be a bug down in the ROS 2 core, but for now this should work around it.