### PR TITLE
Make ros_environment a build_depend

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,8 +14,8 @@
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 2">rosidl_default_generators</buildtool_depend>
 
+  <build_depend>ros_environment</build_depend>
   <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
-  <build_depend condition="$ROS_VERSION == 1">ros_environment</build_depend>
   <build_depend condition="$ROS_VERSION == 2">builtin_interfaces</build_depend>
 
   <depend>std_msgs</depend>


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should resolve the current build failure, like https://build.ros2.org/job/Rbin_uJ64__rtcm_msgs__ubuntu_jammy_amd64__binary/49/consoleFull